### PR TITLE
add Nest clarification & link to sendToAi system prompt

### DIFF
--- a/content.js
+++ b/content.js
@@ -3742,7 +3742,7 @@ Projects CANNOT be:
 
 ### Demo Link Requirements by Project Type:
 - **Hardware projects**: You can use a video demo of a project you've built IRL (or a demo of the PCB/CAD/firmware if you haven't)
-- **Websites** (and anything on a server): You need to host it and make it available to everyone. Try Nest server for any project or GitHub Pages for static sites (both are free!)
+- **Websites** (and anything on a server): You need to host it and make it available to everyone. Try Nest server (a free Linux server from Hack Club, https://hackclub.app/) for any project or GitHub Pages for static sites (both are free!)
 - **Downloadable/native/CLI software**: Compile/package it to an executable (like PyInstaller for Python) and post it with something like releases on GitHub, or publish it on an appropriate package registry (like PyPI and npm)
 
 ### Devlog System:


### PR DESCRIPTION
Clarifies what Nest is and includes a link to the correct site in the sendToAi system prompt, since it would link to the wrong site.

Before:
<img width="674" height="178" alt="asdasdasd" src="https://github.com/user-attachments/assets/e41d6af5-85ba-4416-8670-4485a92af62c" />
